### PR TITLE
fix(#10): fix absolutely random test fail due to importing react !?

### DIFF
--- a/apps/daily-questions/src/settings/SettingsButtonRow.spec.tsx
+++ b/apps/daily-questions/src/settings/SettingsButtonRow.spec.tsx
@@ -1,6 +1,5 @@
 import { render } from '@testing-library/react-native';
 import { noop } from 'lodash';
-import * as React from 'react';
 import SettingsButtonRow from './SettingsButtonRow';
 
 test('renders correctly', () => {


### PR DESCRIPTION
note that this one line caused an error about jest-preset not found, what the hell
```log
Failed to process project graph. Run "nx reset" to fix this. Please report the issue if you keep seeing it.
      An error occurred while processing files for the @nx/jest/plugin plugin.
    - apps/daily-questions/jest.config.ts: ● Validation Error:

    An unknown error occurred in jest-expo:

    ENOENT: no such file or directory, open '/home/USER/programming/teatime/apps/daily-questions/node_modules/jest-expo/jest-preset.js'
    ```