### PR TITLE
fix(#2 #13): dailies nav and autofocus on edge cases

### DIFF
--- a/apps/daily-questions/src/dailies/FulltextQuestionScreen.tsx
+++ b/apps/daily-questions/src/dailies/FulltextQuestionScreen.tsx
@@ -1,6 +1,6 @@
 import { Button, Paragraph, TextInput, Title } from '@teatime/rnp-components';
-import React, { FC, useEffect, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, { FC, useEffect, useRef, useState } from 'react';
+import { StyleSheet, View, type TextInput as RNTextInput } from 'react-native';
 import { connect, ConnectedProps } from 'react-redux';
 import { useTranslation } from '../localization/useTranslations';
 import { RootState } from '../store';
@@ -58,8 +58,12 @@ const FulltextQuestionScreen: FC<Props & PropsFromRedux> = ({
   const { t } = useTranslation();
   const [text, setText] = useState(answer?.toString() ?? '');
   const [errored, setError] = useState(false);
+  const textInput = useRef<RNTextInput | null>(null);
   useEffect(() => {
     setText(answer?.toString() ?? '');
+    const shouldFocus =
+      textInput.current && !textInput.current.isFocused() && autofocusEnabled;
+    if (shouldFocus) textInput.current?.focus();
   }, [id, answer]);
 
   const onNext = () => {
@@ -80,6 +84,7 @@ const FulltextQuestionScreen: FC<Props & PropsFromRedux> = ({
       <Title style={styles.title}>{title}</Title>
       <Paragraph>{questionLong}</Paragraph>
       <TextInput
+        ref={textInput}
         label={title}
         multiline={true}
         onChangeText={handleChangeText}

--- a/apps/daily-questions/src/dailies/PointsQuestionScreen.tsx
+++ b/apps/daily-questions/src/dailies/PointsQuestionScreen.tsx
@@ -1,7 +1,11 @@
 import { Button, Paragraph, TextInput, Title } from '@teatime/rnp-components';
 import { inRange } from 'lodash';
-import React, { FC, useEffect, useState } from 'react';
-import { ScrollView, StyleSheet } from 'react-native';
+import React, { FC, useEffect, useRef, useState } from 'react';
+import {
+  ScrollView,
+  StyleSheet,
+  type TextInput as RNTextInput,
+} from 'react-native';
 import { connect, ConnectedProps } from 'react-redux';
 import { useTranslation } from '../localization/useTranslations';
 import { RootState } from '../store';
@@ -66,9 +70,13 @@ const PointsQuestionScreen: FC<Props & PropsFromRedux> = ({
 }) => {
   const { t } = useTranslation();
   const [answerInput, setAnswerInput] = useState(answer?.toString() ?? '');
+  const textInput = useRef<RNTextInput | null>(null);
   useEffect(() => {
     // since we are using the same screen for different questions, we need to reset the input field when the question changes
     setAnswerInput(answer?.toString() ?? '');
+    const shouldFocus =
+      textInput.current && !textInput.current.isFocused() && autofocusEnabled;
+    if (shouldFocus) textInput.current?.focus();
   }, [setAnswerInput, id]);
 
   const handleChangeText = (text: string | undefined): void => {
@@ -90,6 +98,7 @@ const PointsQuestionScreen: FC<Props & PropsFromRedux> = ({
       <Title style={styles.title}>{title}</Title>
       <Paragraph>{questionLong}</Paragraph>
       <TextInput
+        ref={textInput}
         label={title}
         keyboardType="numeric"
         onChangeText={handleChangeText}


### PR DESCRIPTION
16 different cases

```
- (default) autofocus=true, autonav=true, from full text question to full text question
- (default) autofocus=true, autonav=true, from points question to points question
- (default) autofocus=true, autonav=true, from points question to full text question
- (default) autofocus=true, autonav=true, from full text question to points question
- (focus) autofocus=true, autonav=false, from full text question to full text question
- (focus) autofocus=true, autonav=false, from points question to points question
- (focus) autofocus=true, autonav=false, from points question to full text question
- (focus) autofocus=true, autonav=false, from full text question to points question
- (manual labor) autofocus=false, autonav=false, from points question to points question
- (manual labor) autofocus=false, autonav=false, from full text question to full text question
- (manual labor) autofocus=false, autonav=false, from points question to full text question
- (manual labor) autofocus=false, autonav=false, from full text question to points question
- (nav) autofocus=false, autonav=true, from points question to points question
- (nav) autofocus=false, autonav=true, from full text question to full text question
- (nav) autofocus=false, autonav=true, from points question to full text question
- (nav) autofocus=false, autonav=true, from full text question to points question

Expectation is identical to (autofocus, autonav) tuple.
```

[Testing focus is not possible with testing-lib react native bc of how it renders react native stuff. it would be possible with detox](https://stackoverflow.com/a/70922025)